### PR TITLE
remove @return php-doc on constructors

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -47,7 +47,6 @@ class Connection
      * @param string $header
      *
      * @throws InvalidArgumentException
-     * @return void
      */
     public function __construct($client = 'SoapClient', $header = 'SoapHeader')
     {
@@ -62,7 +61,7 @@ class Connection
             return $result;
         };
 
-        $this->client = $load($client, self::CLASS_SOAPCLIENT); 
+        $this->client = $load($client, self::CLASS_SOAPCLIENT);
         $this->header = $load($header, self::CLASS_SOAPHEADER);
 
         $this->options['classmap'] = [

--- a/src/Response/GetListIDResponse.php
+++ b/src/Response/GetListIDResponse.php
@@ -28,9 +28,6 @@ class GetListIDResponse extends Response
      */
     protected $id;
 
-    /**
-     * @return void
-     */
     public function __construct()
     {
         $this->GetListIDResult = 0;

--- a/src/Response/GetListsResponse.php
+++ b/src/Response/GetListsResponse.php
@@ -29,9 +29,6 @@ class GetListsResponse extends Response
      */
     protected $lists;
 
-    /**
-     * @return void
-     */
     public function __construct()
     {
         $this->GetListsResult = Response::ERROR_NORESULT;

--- a/src/Response/GetSystemStatusResponse.php
+++ b/src/Response/GetSystemStatusResponse.php
@@ -23,9 +23,6 @@ class GetSystemStatusResponse extends Response
      */
     protected $GetSystemStatusResult;
 
-    /**
-     * @return void
-     */
     public function __construct()
     {
         $this->GetSystemStatusResult = 'error (unknown)';
@@ -36,14 +33,14 @@ class GetSystemStatusResponse extends Response
      */
     public function getCode()
     {
-        /* This is supposed to always returns something. 
+        /* This is supposed to always returns something.
            So it's always successful*/
         return Response::SUCCESSFUL;
     }
 
     /**
      *
-     * @return string System status 
+     * @return string System status
      */
     public function getStatus()
     {
@@ -53,7 +50,7 @@ class GetSystemStatusResponse extends Response
 
     /**
      *
-     * @return string Provider API version 
+     * @return string Provider API version
      */
     public function getVersion()
     {


### PR DESCRIPTION
> Adding a @return annotation to constructors is generally not recommended as a constructor does not have a meaningful return value. 