### PR TITLE
📢 Add Broadcast Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://secure.travis-ci.org/mediapart/selligent.svg?branch=master)](http://travis-ci.org/mediapart/selligent) [![Code Coverage](https://codecov.io/gh/mediapart/selligent/branch/master/graph/badge.svg)](https://scrutinizer-ci.com/g/mediapart/selligent) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/mediapart/selligent/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mediapart/selligent) [![Total Downloads](https://poser.pugx.org/mediapart/selligent/downloads.png)](https://packagist.org/packages/mediapart/selligent) [![Latest Stable Version](https://poser.pugx.org/mediapart/selligent/v/stable.png)](https://packagist.org/packages/mediapart/selligent)
 
+A simple PHP library to help you interact with both Selligent Individual and Broadcast API.
+
 
 ## Usage
 
@@ -54,6 +56,8 @@ try {
 }
 ```
 
+You could [broadcast campaign based on complete HTML](doc/Broadcast.md) from the API.
+
 
 ## Installation
 
@@ -64,35 +68,19 @@ composer require mediapart/selligent
 ```
 
 
-## Test
+## Tests
 
-Executing `default` test suite :
+Executing tests out of the box :
 
 ```bash
-./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite default
+./vendor/bin/phpunit
 ```
 
-### Test by connecting to a Soap server
-
-With the `real` testsuite, you could execute a serie of test who will be applied to a given host. Some environment variables are required to execute RealTestSuite :
-
-- soap_login
-- soap_password
-- soap_wsdl_individual
-- soap_wsdl_broadcast
-- selligent_list
-- selligent_gate
-- selligent_folderid 
-- selligent_maildomainid 
-- selligent_listid 
-- selligent_segmentid 
-- selligent_queueid 
-- selligent_macategory 
+Without setting [some environment variables](./doc/Tests.md), some tests will be skipped. Tests in `real` testsuite for example.
 
 
 ## Read More
 
-- Illustrated [Reference](doc/Reference/Readme.md) of all available API endpoints.
-- Little use case [Example](doc/Example.md) from connection to triggering campaign
+- Illustrated [Reference](doc/Reference/Readme.md) of all available API endpoints ;
+- Little use case [Example](doc/Example.md) from connection to triggering campaign ;
 - You could use PSR3 to [log informations from this library](doc/Logging.md).
-- You could [broadcast campaign based on complete HTML](doc/Broadcast.md) from the API.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/config": "^3.1"
     },
      "require-dev": {
-        "phpunit/phpunit": "*",
-        "ext-xdebug": "*"
+        "phpunit/phpunit": "*"
     }
 }

--- a/doc/Broadcast.md
+++ b/doc/Broadcast.md
@@ -1,4 +1,3 @@
-
 # Broadcast Complete HTML Campaign
 
 ```php
@@ -33,10 +32,8 @@ $campaign
 ;
 // ... 
 
-$writer = new XMLWriter();
-$request = new CreateCampaign($writer);
-$xml = $request->basedOn($campaign);
-$response = $this->client->CreateCampaign(['Xml' => $xml]);
+$broadcast = new Broadcast($client);
+$response = $broadcast->triggerCampaign($campaign);
 
 if ($response==Response::SUCCESSFUL) {
     print 'Your campaign has been created';

--- a/doc/Logging.md
+++ b/doc/Logging.md
@@ -1,4 +1,3 @@
-
 # Logging
 
 This library allows you to connect a [PSR3](http://www.php-fig.org/psr/psr-3/) implementation to log an monitor how it's work.
@@ -22,22 +21,19 @@ use Mediapart\Selligent\Connection;
 use Mediapart\Selligent\Transport;
 use Mediapart\Selligent\Properties;
 
-$log = new Logger('selligent');
-$log->pushHandler(new StreamHandler('monolog-example.log'));
+$logger = new Logger('selligent');
+$logger->pushHandler(new StreamHandler('monolog-example.log'));
 
-$configFile = file_get_contents(
-	__DIR__.'/config/individual_default_config.yaml'
-);
-$cfg = new \Mediapart\Selligent\Configuration();
-
-
-$con = new Connection();
-$con->setLogger($log);
-
-$client = $con->open($cfg->loadConfig($configFile));
+$connection = new Connection();
+$connection->setLogger($logger);
+$client = $connection->open([
+    'login' => '*****',
+    'password' => '*****',
+    'wsdl' => 'http://emsecure/individual?wsdl', 
+]);
 
 $transport = new Transport($client);
-$transport->setLogger($log);
+$transport->setLogger($logger);
 $transport->setList('TESTLIST');
 
 $user = new Properties();
@@ -46,5 +42,3 @@ $user['MAIL'] = 'foo@bar.tld';
 $transport->subscribe($user);
 
 ```
-
-

--- a/doc/Tests.md
+++ b/doc/Tests.md
@@ -1,0 +1,27 @@
+# Testing the library
+
+
+## Default tests
+
+```bash
+./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite default
+```
+
+
+## Integrated tests
+
+With the `real` testsuite, you could execute a serie of tests who will be applied to a given host. 
+Some environment variables are required to execute integrated tests :
+
+- soap_login
+- soap_password
+- soap_wsdl_individual
+- soap_wsdl_broadcast
+- selligent_list
+- selligent_gate
+- selligent_folderid 
+- selligent_maildomainid 
+- selligent_listid 
+- selligent_segmentid 
+- selligent_queueid 
+- selligent_macategory 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,12 +6,12 @@
   <testsuites>
     <testsuite name="default">
       <directory>./tests</directory>
-      <exclude>./tests/IndividualTest.php</exclude>
-      <exclude>./tests/BroadcastTest.php</exclude>
+      <exclude>./tests/Integrated/IndividualTest.php</exclude>
+      <exclude>./tests/Integrated/BroadcastTest.php</exclude>
     </testsuite>
     <testsuite name="real">
-      <file>./tests/IndividualTest.php</file>
-      <file>./tests/BroadcastTest.php</file>
+      <file>./tests/Integrated/IndividualTest.php</file>
+      <file>./tests/Integrated/BroadcastTest.php</file>
     </testsuite>
   </testsuites>
 

--- a/src/Broadcast.php
+++ b/src/Broadcast.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the Mediapart Selligent Client API
+ *
+ * CC BY-NC-SA <https://github.com/mediapart/selligent>
+ *
+ * For the full license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mediapart\Selligent;
+
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Mediapart\Selligent\Broadcast\Campaign;
+use Mediapart\Selligent\Request\CreateCampaign;
+
+/**
+ *
+ */
+class Broadcast implements LoggerAwareInterface
+{
+    /**
+     * @var \XMLWriter
+     */
+    protected $writer;
+
+    /**
+     * @var \SoapClient
+     */
+    protected $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger = null;
+
+    /**
+     * @param \SoapClient $client
+     * @param string $list
+     * @param string $campaign
+     */
+    public function __construct(\SoapClient $client)
+    {
+        $this->writer = new \XMLWriter();
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Campaign $campaign
+     * @return CreateCampaignResponse
+     */
+    public function triggerCampaign(Campaign $campaign)
+    {
+        $request = new CreateCampaign($this->writer);
+        $response = $this->client->CreateCampaign([
+            'Xml' => $request->basedOn($campaign)
+        ]);
+
+        if ($this->logger) {
+
+            if (Response::SUCCESSFUL !== $response->getCode()) {
+                $level = LogLevel::ERROR;
+                $message = 'triggerCampaign has failed';
+            } else {
+                $level = LogLevel::INFO;
+                $message = 'triggerCampaign with success';
+            }
+
+            $this->logger->log(
+                $level,
+                $message,
+                [
+                    'campaign' => [
+                        'name' => $campaign->getName(),
+                        'status' => $campaign->getStatus(),
+                        'stdate' => $campaign->getStartDate()->format(\DateTime::RFC850),
+                    ],
+                    'response' => [
+                        'code' => $response->getCode(),
+                        'error' => $response->getError(),
+                        'result' => $response->getXml(),
+                    ],
+                ]
+            );
+        }
+
+        return $response;
+    }
+}

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -19,7 +19,7 @@ use Mediapart\Selligent\Response\GetUserByFilterResponse;
 /**
  *
  */
-class Transport
+class Transport implements LoggerAwareInterface
 {
     /**
      * @var \SoapClient

--- a/tests/Integrated/BroadcastTest.php
+++ b/tests/Integrated/BroadcastTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the Mediapart Selligent Client API
+ *
+ * CC BY-NC-SA <https://github.com/mediapart/selligent>
+ *
+ * For the full license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mediapart\Selligent\Tests\Integrated;
+
+use \XMLWriter;
+use Mediapart\Selligent\Response;
+use Mediapart\Selligent\Broadcast\Campaign;
+use Mediapart\Selligent\Broadcast\Target;
+use Mediapart\Selligent\Broadcast\Email;
+use Mediapart\Selligent\Request\CreateCampaign;
+use Mediapart\Selligent\Tests\Integrated\IntegrationTestCase;
+
+/**
+ *
+ */
+class BroadcastTest extends IntegrationTestCase
+{
+    /**
+     *
+     */
+    protected function setUp()
+    {
+        $this->requireEnv([
+            'soap_login',
+            'soap_password',
+            'soap_wsdl_broadcast',
+            'selligent_folderid',
+            'selligent_maildomainid',
+            'selligent_listid',
+            'selligent_segmentid',
+            'selligent_queueid',
+            'selligent_macategory',
+        ]);
+
+        $con = new Connection();
+        $this->client = $con->open(
+            [
+                'login' => getenv('soap_login'),
+                'password' => getenv('soap_password'),
+                'wsdl' => getenv('soap_wsdl_broadcast'),
+            ],
+            Connection::API_BROADCAST
+        );
+    }
+
+    /**
+     *
+     */
+    public function testCompleteHTML()
+    {
+        $tomorrow = new \DateTime('tomorrow');
+
+        $campaign = new Campaign();
+        $campaign
+            ->setName('Broadcast Test ('.$tomorrow->format('l, jS F').')')
+            ->setFolderId(getenv('selligent_folderid'))
+            ->setState(Campaign::ACTIVE)
+            ->setStartDate($tomorrow)
+            ->setDescription(sprintf(
+                'Some broadcast test scheduled for the %s at %s.',
+                $tomorrow->format('L, jS F'),
+                $tomorrow->format('g:ia')
+            ))
+        ;
+        $target = new Target();
+        $target
+            ->setListId(getenv('selligent_listid'))
+            ->setPriorityField('CREATED_DT')
+            ->setPrioritySorting('DESC')
+            ->setSegmentid(getenv('selligent_segmentid'))
+        ;
+        $email = new Email();
+        $email
+            ->setName('Broadcast Email Test ('.$tomorrow->format('l, jS F').')')
+            ->setFolderId(getenv('selligent_folderid'))                                       
+            ->setMailDomainId(getenv('selligent_maildomainid'))
+            ->listUnsubscribe(false)
+            ->setQueueId(getenv('selligent_queueid'))
+            ->setMaCategory(getenv('selligent_macategory'))
+            ->setTarget($target)
+            ->setContent([
+                'HTML' => 'html over here.',
+                'TEXT' => 'text over there.',
+                'FROM_ADDR' => 'from@domain.tld',
+                'FROM_NAME' => 'From Name',
+                'TO_ADDR' => '~MAIL~',
+                'TO_NAME' => '~NAME~',
+                'REPLY_ADDR' => 'reply-to@domain.tld',
+                'REPLY_NAME' => 'Reply To',
+                'SUBJECT' => sprintf(
+                    '%s at %s.',
+                    $tomorrow->format('l, jS F'),
+                    $tomorrow->format('g:ia')
+                ),
+            ])
+        ;
+        $campaign->addEmail($email);
+
+        $writer = new XMLWriter();
+        $request = new CreateCampaign($writer);
+        $xml = $request->basedOn($campaign);
+        $response = $this->client->CreateCampaign(['Xml' => $xml]);
+
+        $this->assertEquals('', $response->getError());
+        $this->assertEquals(Response::SUCCESSFUL, $response->getCode());
+    }
+}

--- a/tests/Integrated/IndividualTest.php
+++ b/tests/Integrated/IndividualTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Mediapart\Selligent\Tests;
+namespace Mediapart\Selligent\Tests\Integrated;
 
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Config\Definition\Processor;
 use Mediapart\Selligent\Configuration;
-use Mediapart\Selligent\Tests\RealTestCase;
+use Mediapart\Selligent\Tests\Integrated\IntegrationTestCase;
 
 /**
  *
  */
-class IndividualTest extends RealTestCase
+class IndividualTest extends IntegrationTestCase
 {
     const API_VERSION = 'v6.3';
 

--- a/tests/Integrated/IntegrationTestCase.php
+++ b/tests/Integrated/IntegrationTestCase.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Mediapart\Selligent\Tests;
+namespace Mediapart\Selligent\Tests\Integrated;
 
 /**
  *
  */
-class RealTestCase extends \PHPUnit_Framework_TestCase
+class IntegrationTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      *


### PR DESCRIPTION
In the same idea that the [Transport](https://github.com/mediapart/selligent/blob/v1.0.1/src/Transport.php) class, I proposed to add a `Broadcast` class to helps library end user to trigger broadcasted campaigns.

```php
$broadcast = new Broadcast($client);
$broadcast->setLogger($logger);
$response = $broadcast->triggerCampaign($campaign);
```

Due to naming conflicts, I moved `IndividualTest` and `BroadcastTest` into `tests/Integrated/`.
