### PR TITLE
🔗 handle HYPERLINKS_TO_SENSORS attribute

### DIFF
--- a/doc/Broadcast.md
+++ b/doc/Broadcast.md
@@ -43,3 +43,13 @@ if ($response==Response::SUCCESSFUL) {
 }
 
 ```
+
+## HYPERLINKS_TO_SENSORS Attribute
+
+Convert all your hyperlinks to sensors in your email :
+
+```php
+<?php
+$email = new Email();
+$email->setHyperlinksToSensors(true);
+```

--- a/src/Broadcast/Email.php
+++ b/src/Broadcast/Email.php
@@ -59,7 +59,12 @@ class Email
     /**
      * @var array
      */
-    private $content;
+    private $content = [];
+
+    /**
+     * @var boolean
+     */
+    protected $hyperlinks_to_sensors = false;
 
     /**
      * @param string $name The name as defined for the email message properties.
@@ -243,5 +248,26 @@ class Email
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * Set this value to TRUE when your hyperlinks must be converted to sensors.
+     *
+     * @param boolean $hyperlinks_to_sensors
+     * @return self
+     */
+    public function setHyperlinksToSensors($hyperlinks_to_sensors = true)
+    {
+        $this->hyperlinks_to_sensors = $hyperlinks_to_sensors;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasHyperlinksToSensors()
+    {
+        return $this->hyperlinks_to_sensors;
     }
 }

--- a/src/Request/CreateCampaign.php
+++ b/src/Request/CreateCampaign.php
@@ -157,6 +157,9 @@ class CreateCampaign
         $this->target($email->getTarget());
 
         $this->writer->startElement('CONTENT');
+        if ($email->hasHyperlinksToSensors()) {
+            $this->attr('HYPERLINKS_TO_SENSORS', 1);
+        }
         foreach ($email->getContent() as $key => $value) {
             $this->writer->startElement($key);
             $this->writer->startCData();

--- a/tests/Broadcast/HyperlinkToSensorsTest.php
+++ b/tests/Broadcast/HyperlinkToSensorsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Mediapart Selligent Client API
+ *
+ * CC BY-NC-SA <https://github.com/mediapart/selligent>
+ *
+ * For the full license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mediapart\Selligent\Tests\Broadcast;
+
+use \XMLWriter;
+use Mediapart\Selligent\Request\CreateCampaign;
+use Mediapart\Selligent\Broadcast\Campaign;
+use Mediapart\Selligent\Broadcast\Target;
+use Mediapart\Selligent\Broadcast\Email;
+
+/**
+ *
+ */
+class HyperlinkToSensorsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     *
+     */
+    public function testEmailAttribute()
+    {
+        $email = new Email();
+
+        $email->setHyperlinksToSensors(true);
+
+        $this->assertTrue($email->hasHyperlinksToSensors());
+    }
+
+    /**
+     *
+     */
+    public function testCreateCampaign()
+    {
+        $campaign = new Campaign();
+        $target = new Target();
+        $email = new Email();
+        $email
+            ->setTarget($target)
+            ->setHyperlinksToSensors(true)
+        ;
+        $campaign->addEmail($email);
+
+        $writer = new XMLWriter();
+        $request = new CreateCampaign($writer);
+        $xml = $request->basedOn($campaign);
+
+        $document = simplexml_load_string($xml);
+        $this->assertEquals(1, (int) $document->EMAILS->EMAIL[0]->CONTENT->attributes()->HYPERLINKS_TO_SENSORS);
+    }
+}


### PR DESCRIPTION
Adding the ability to use the `HYPERLINKS_TO_SENSORS` attribute in broadcast campaigns if you want a hyperlink to be measured as a sensor.

```php
<?php
use Mediapart\Selligent\Broadcast\Email;

$email = new Email();
$email->setHyperlinksToSensors(true);
```
